### PR TITLE
Fix cisco_ios_show_int_switchport parsing to handle trunk allowed vlan

### DIFF
--- a/src/nornir_validate/feature_templates/interface/interface_actual_state.py
+++ b/src/nornir_validate/feature_templates/interface/interface_actual_state.py
@@ -225,10 +225,14 @@ def format_swport(val_file: bool, output: list[dict[str, Any]]) -> dict[str, Any
             result[each_intf["interface"]]["vlan"] = _make_int(each_intf["access_vlan"])
         elif bool(re.search("trunk", each_intf["mode"])):
             trunk_vl = each_intf["trunking_vlans"]
-            try:
+            # If is a string (NXOS) split into list of VLANs based on ","
+            if isinstance(trunk_vl, str):
                 trunk_vl = [_make_int(vl) for vl in trunk_vl.split(",")]
-            except AttributeError:
-                trunk_vl = [_make_int(vl) for vl in trunk_vl[0].split(",")]
+            # If is already a list of VLANs (IOS), if possible make them integers
+            elif isinstance(trunk_vl, list):
+                trunk_vl = [_make_int(vl) for vl in trunk_vl]
+            else:
+                trunk_vl = None
             result[each_intf["interface"]]["vlan"] = trunk_vl
         else:
             result[each_intf["interface"]]["vlan"] = None

--- a/tests/os_test_files/cisco_ios/interface/cisco_ios_interface_cmd_output.json
+++ b/tests/os_test_files/cisco_ios/interface/cisco_ios_interface_cmd_output.json
@@ -65,7 +65,7 @@
                 "access_vlan": "1",
                 "native_vlan": "1",
                 "voice_vlan": "none",
-                "trunking_vlans": ["144,3101,3102"]
+                "trunking_vlans": ["144","3101","3102"]
             },
             {
                 "interface": "Gi0/2",


### PR DESCRIPTION
Fix [issue 14](https://github.com/sjhloco/nornir-validate/issues/14) by adding handling of trunk allowed VLANs as a list of VLANs rather than the old method of a string that needed splitting into a list